### PR TITLE
fix: pod command not works after ruby update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ronnnnn

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@
   - [RubyGems](https://rubygems.org/?locale=en): manage Ruby packages.
 - [Bundler](https://bundler.io): make downloaded cocoapods binary executable.
 
+## Recommendation
+
+Use Ruby and Bundler installed via asdf.
+
+- [asdf-vm/asdf-ruby](https://github.com/asdf-vm/asdf-ruby)
+- [jonathanmorley/asdf-bundler](https://github.com/jonathanmorley/asdf-bundler)
+
 # Install
 
 Plugin:

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -59,6 +59,7 @@ install_version() {
 		local tool_cmd
 		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
 
+		bundle config set path "vendor/bundle"
 		bundle install --gemfile="$install_path/Gemfile"
 
 		test -x "$install_path/bin/$tool_cmd" || fail "Expected $install_path/bin/$tool_cmd to be executable."


### PR DESCRIPTION
fix #3

If you install CocoaPods with Bundler without path setting, the pod command depends on Ruby version.
Therefore, I added global path configuration before `bundle install` to install the pod command.